### PR TITLE
BUG-201: PyJWT v1.0.7 introduces a bug where PyCrypto becomes a required...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'PyJWT>=0.1.6',
+        'PyJWT==0.1.6',
         'requests>=2.2.0',
     ],
     license="BSD",


### PR DESCRIPTION
... dependency.

The fix has been committed, but not yet released to PyPI. In the meantime, pin to v0.1.6.
